### PR TITLE
Updated security group with WinRM port (5985)

### DIFF
--- a/templates/fsx-windows.yaml
+++ b/templates/fsx-windows.yaml
@@ -297,6 +297,10 @@ Resources:
           ToPort: 3269
           CidrIp: !Ref FSxAllowedCIDR
         - IpProtocol: tcp
+          FromPort: 5985
+          ToPort: 5985
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: tcp
           FromPort: 9389
           ToPort: 9389
           CidrIp: !Ref FSxAllowedCIDR


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Added WinRM port which is required for [FSx CLI RM PowerShell](https://docs.aws.amazon.com/fsx/latest/WindowsGuide/remote-pwrshell.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
